### PR TITLE
Envars for listening port, NR app name.  Support for call to other URL.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -1,0 +1,26 @@
+on: [push, pull_request]
+name: Tests
+jobs:
+  test:
+    strategy:
+      matrix:
+        go-version: [1.13.x, 1.14.x]
+        platform: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.platform }}
+    steps:
+    - name: Install Go
+      uses: actions/setup-go@v2
+      with:
+        go-version: ${{ matrix.go-version }}
+
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Get dependencies
+      run: go get -v -t -d ./...
+
+    - name: Build
+      run: go build -v .
+
+    - name: Test
+      run: go test ./...

--- a/README.md
+++ b/README.md
@@ -24,8 +24,11 @@ The default listening port is 8080.
   Golang Duration string format). Default: `100ms`
 
 ## Remote example call to fiber-http server
-```% curl "http://localhost:8080/call?url=http://localhost:8000/cpu?duration=250ms"
-consumed CPU for 250ms```
+
+```
+% curl "http://localhost:8080/call?url=http://localhost:8000/cpu?duration=250ms"
+consumed CPU for 250ms
+```
 
 The resource endpoints of `cpu`, `memory`, and `time` are useful for triggering
 the artificial consumption of resources for testing autoscale behaviors, error

--- a/README.md
+++ b/README.md
@@ -30,8 +30,10 @@ A [Prometheus](https://prometheus.io/) metrics endpoint is exposed at `/metrics`
 that can be scraped.
 
 [New Relic](https://newrelic.com/) instrumentation can be activated by setting
-the `NEW_ RELIC_LICENSE_KEY` environment variable to a valid New Relic license
+the `NEW_RELIC_LICENSE_KEY` environment variable to a valid New Relic license
 key. The middleware will activate and log a status message after initialization.
+
+Set `NEW_RELIC_APP_NAME` to define the corresponding New Relic APM identifier (default: `fiber-http`).
 
 ## Docker images
 

--- a/README.md
+++ b/README.md
@@ -23,16 +23,16 @@ The default listening port is 8080.
 * `/time{?duration}` - Consume time by sleeping for the given duration (in
   Golang Duration string format). Default: `100ms`
 
+The resource endpoints of `cpu`, `memory`, and `time` are useful for triggering
+the artificial consumption of resources for testing autoscale behaviors, error
+handling, response to latency, etc.
+
 ## Remote example call to fiber-http server
 
 ```
 % curl "http://localhost:8080/call?url=http://localhost:8000/cpu?duration=250ms"
 consumed CPU for 250ms
 ```
-
-The resource endpoints of `cpu`, `memory`, and `time` are useful for triggering
-the artificial consumption of resources for testing autoscale behaviors, error
-handling, response to latency, etc.
 
 ## Instrumentation
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,12 @@ throughput, predictable performance, and metrics instrumentation.
 Built with [Fiber](https://docs.gofiber.io/) and
 [FastHTTP](https://github.com/valyala/fasthttp).
 
-The app exposes several endpoints:
+## Listening port
+Set environment variable FIBER_HTTP_LISTEN_PORT to the desired TCP listening port.
+
+The default listening port is 8080.
+
+## Exposed endpoints
 
 * `/` - Returns a 200 (Ok) `text/plain` respomse.
 * `/metrics` - Metrics in Prometheus format for scraping.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,10 @@ The default listening port is 8080.
 * `/time{?duration}` - Consume time by sleeping for the given duration (in
   Golang Duration string format). Default: `100ms`
 
+## Remote example call to fiber-http server
+```% curl "http://localhost:8080/call?url=http://localhost:8000/cpu?duration=250ms"
+consumed CPU for 250ms```
+
 The resource endpoints of `cpu`, `memory`, and `time` are useful for triggering
 the artificial consumption of resources for testing autoscale behaviors, error
 handling, response to latency, etc.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ The app exposes several endpoints:
 
 * `/` - Returns a 200 (Ok) `text/plain` respomse.
 * `/metrics` - Metrics in Prometheus format for scraping.
+* `call{?url}` - Have fiber-http to call out to another URL.
 * `/cpu{?duration}` - Consume CPU resources for the given duration (in Golang
   Duration string format). Default: `100ms`
 * `/memory{?size}` - Consume memory resources by allocating a byte array of the

--- a/README.md
+++ b/README.md
@@ -6,33 +6,26 @@ throughput, predictable performance, and metrics instrumentation.
 Built with [Fiber](https://docs.gofiber.io/) and
 [FastHTTP](https://github.com/valyala/fasthttp).
 
-## Listening port
-Set environment variable FIBER_HTTP_LISTEN_PORT to the desired TCP listening port.
-
-The default listening port is 8080.
-
 ## Exposed endpoints
 
-* `/` - Returns a 200 (Ok) `text/plain` respomse.
+* `/` - Returns a 200 (Ok) `text/plain` response of "move along, nothing to see here".
 * `/metrics` - Metrics in Prometheus format for scraping.
-* `/call{?url}` - Have fiber-http to call out to another URL.
 * `/cpu{?duration}` - Consume CPU resources for the given duration (in Golang
   Duration string format). Default: `100ms`
 * `/memory{?size}` - Consume memory resources by allocating a byte array of the
   given size (in human readable byte string format). Default: `10MB`
 * `/time{?duration}` - Consume time by sleeping for the given duration (in
   Golang Duration string format). Default: `100ms`
+* `/request{?url}` - Proxy an HTTP GET request to a URL and return the status code & message body retrieved..
 
 The resource endpoints of `cpu`, `memory`, and `time` are useful for triggering
 the artificial consumption of resources for testing autoscale behaviors, error
 handling, response to latency, etc.
 
-## Remote example call to fiber-http server
-
-```
-% curl "http://localhost:8080/call?url=http://localhost:8000/cpu?duration=250ms"
-consumed CPU for 250ms
-```
+The `request` endpoint enables testing of service dependencies and can be reentrantly
+chained. For example, when running an instance locally on port 8080 a request made
+to `http://localhost:8080/request?url=http://localhost:8080/time?duration=45ms` would
+simulate an upstream service with a 45ms latency.
 
 ## Instrumentation
 
@@ -47,6 +40,11 @@ the `NEW_RELIC_LICENSE_KEY` environment variable to a valid New Relic license
 key. The middleware will activate and log a status message after initialization.
 
 Set `NEW_RELIC_APP_NAME` to define the corresponding New Relic APM identifier (default: `fiber-http`).
+
+## Listening port
+
+By default, the server listens on port 8080. The port can be changed via the `PORT`
+environment variable.
 
 ## Docker images
 

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/newrelic/go-agent v3.8.1+incompatible // indirect
 	github.com/newrelic/go-agent/v3 v3.8.1
 	github.com/prometheus/common v0.13.0 // indirect
+	github.com/valyala/fasthttp v1.16.0
 	go.uber.org/automaxprocs v1.3.0
 	golang.org/x/lint v0.0.0-20200302205851-738671d3881b // indirect
 	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect

--- a/go.mod
+++ b/go.mod
@@ -16,5 +16,6 @@ require (
 	golang.org/x/sys v0.0.0-20200826173525-f9321e4c35a6 // indirect
 	golang.org/x/tools v0.0.0-20200828013309-97019fc2e64b // indirect
 	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
+	gopkg.in/valyala/fasthttp.v20160316 v20160316.0.0-20160315092703-2b172da53920 // indirect
 	honnef.co/go/tools v0.0.1-2020.1.5 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -458,6 +458,8 @@ gopkg.in/fsnotify.v1 v1.4.7/go.mod h1:Tz8NjZHkW78fSQdbUxIjBTcgA1z1m8ZHf0WmKUhAMy
 gopkg.in/gcfg.v1 v1.2.3/go.mod h1:yesOnuUOFQAhST5vPY4nbZsb/huCgGGXlipJsBn0b3o=
 gopkg.in/resty.v1 v1.12.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=
 gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7/go.mod h1:dt/ZhP58zS4L8KSrWDmTeBkI65Dw0HsyUHuEVlX15mw=
+gopkg.in/valyala/fasthttp.v20160316 v20160316.0.0-20160315092703-2b172da53920 h1:0+rGTKKxU/zIR0C4Hyn0GaYuhZ8SkNaXxlNK9MQb5SM=
+gopkg.in/valyala/fasthttp.v20160316 v20160316.0.0-20160315092703-2b172da53920/go.mod h1:/IagaHIg9ZyOqEpo8qr4kO7OlrN5YQLeIHuBdpg0UQI=
 gopkg.in/warnings.v0 v0.1.2/go.mod h1:jksf8JmL6Qr/oQM2OXTHunEvvTAsrWBLb6OOjuVWRNI=
 gopkg.in/yaml.v2 v2.0.0-20170812160011-eb3733d160e7/go.mod h1:JAlM8MvJe8wmxCU4Bli9HhUf9+ttbYbLASfIpnQbh74=
 gopkg.in/yaml.v2 v2.2.1/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=

--- a/main.go
+++ b/main.go
@@ -7,6 +7,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"time"
 
 	"github.com/ansrivas/fiberprometheus"
@@ -47,6 +48,19 @@ func main() {
 	app.Get("/", func(c *fiber.Ctx) {
 		c.Send("move along, nothing to see here")
 	})
+
+  app.Get("/call", func(c *fiber.Ctx) {
+		remoteURL := c.Query("url")
+		if remoteURL == "" {
+			c.Send("no url read, nothing to see here")
+			return
+		}
+		out, err := exec.Command("curl", remoteURL).Output()
+    if err != nil {
+			c.Send(err)
+		}
+		c.Send(out)
+  })
 
 	app.Get("/cpu", func(c *fiber.Ctx) {
 		duration, err := time.ParseDuration(c.Query("duration", "100ms"))

--- a/main.go
+++ b/main.go
@@ -7,9 +7,9 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"os/exec"
 	"strconv"
 	"time"
+	"github.com/valyala/fasthttp"
 
 	"github.com/ansrivas/fiberprometheus"
 	"github.com/gofiber/fiber"
@@ -67,12 +67,15 @@ func main() {
 			c.Send("no url read, nothing to see here")
 			return
 		}
-		out, err := exec.Command("curl", remoteURL).Output()
-    if err != nil {
-			c.Send(err)
-		}
-		c.Send(out)
-  })
+		req := fasthttp.AcquireRequest()
+    resp := fasthttp.AcquireResponse()
+    defer fasthttp.ReleaseRequest(req)
+    defer fasthttp.ReleaseResponse(resp)
+		req.SetRequestURI(remoteURL)
+		fasthttp.Do(req, resp)
+    bodyBytes := resp.Body()
+    c.Send(string(bodyBytes))
+	})
 
 	app.Get("/cpu", func(c *fiber.Ctx) {
 		duration, err := time.ParseDuration(c.Query("duration", "100ms"))

--- a/main.go
+++ b/main.go
@@ -39,7 +39,7 @@ func main() {
 		}
 	}
 
-  newrelicAppName := os.Getenv("NEW_RELIC_APP_NAME")
+        newrelicAppName := os.Getenv("NEW_RELIC_APP_NAME")
 	if newrelicAppName == "" {
 		newrelicAppName = "fiber-http"
 	}
@@ -61,20 +61,20 @@ func main() {
 		c.Send("move along, nothing to see here")
 	})
 
-  app.Get("/call", func(c *fiber.Ctx) {
+        app.Get("/call", func(c *fiber.Ctx) {
 		remoteURL := c.Query("url")
 		if remoteURL == "" {
 			c.Send("no url read, nothing to see here")
 			return
 		}
 		req := fasthttp.AcquireRequest()
-    resp := fasthttp.AcquireResponse()
-    defer fasthttp.ReleaseRequest(req)
-    defer fasthttp.ReleaseResponse(resp)
+                resp := fasthttp.AcquireResponse()
+                defer fasthttp.ReleaseRequest(req)
+                defer fasthttp.ReleaseResponse(resp)
 		req.SetRequestURI(remoteURL)
 		fasthttp.Do(req, resp)
-    bodyBytes := resp.Body()
-    c.Send(string(bodyBytes))
+                bodyBytes := resp.Body()
+                c.Send(string(bodyBytes))
 	})
 
 	app.Get("/cpu", func(c *fiber.Ctx) {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"net/url"
 	"os"
 	"os/exec"
+	"strconv"
 	"time"
 
 	"github.com/ansrivas/fiberprometheus"
@@ -26,6 +27,17 @@ func main() {
 	prometheus := fiberprometheus.New("fiber-http")
 	prometheus.RegisterAt(app, "/metrics")
 	app.Use(prometheus.Middleware)
+
+  listenPort := 8080
+	listenPortInput := os.Getenv("FIBER_HTTP_LISTEN_PORT")
+	if listenPortInput != "" {
+		lp, err := strconv.Atoi(listenPortInput)
+		if err != nil {
+			log.Printf("ERROR setting FIBER_HTTP_LISTEN_PORT: %s\n", err)
+		} else {
+			listenPort = lp
+		}
+	}
 
   newrelicAppName := os.Getenv("NEW_RELIC_APP_NAME")
 	if newrelicAppName == "" {
@@ -100,7 +112,7 @@ func main() {
 		c.Send(fmt.Sprintf("slept for %v\n", duration.String()))
 	})
 
-	app.Listen(8080)
+	app.Listen(listenPort)
 }
 
 // NewRelicMiddleware instruments the request with New Relic

--- a/main.go
+++ b/main.go
@@ -28,7 +28,7 @@ func main() {
 	prometheus.RegisterAt(app, "/metrics")
 	app.Use(prometheus.Middleware)
 
-  listenPort := 8080
+        listenPort := 8080
 	listenPortInput := os.Getenv("FIBER_HTTP_LISTEN_PORT")
 	if listenPortInput != "" {
 		lp, err := strconv.Atoi(listenPortInput)

--- a/main.go
+++ b/main.go
@@ -26,10 +26,14 @@ func main() {
 	prometheus.RegisterAt(app, "/metrics")
 	app.Use(prometheus.Middleware)
 
+  newrelicAppName := os.Getenv("NEW_RELIC_APP_NAME")
+	if newrelicAppName == "" {
+		newrelicAppName = "fiber-http"
+	}
 	// activate New Relic if NEW_RELIC_LICENSE_KEY is in the environment
 	if newrelicLicenseKey := os.Getenv("NEW_RELIC_LICENSE_KEY"); newrelicLicenseKey != "" {
 		newrelicApp, err := newrelic.NewApplication(
-			newrelic.ConfigAppName("fiber-http"),
+			newrelic.ConfigAppName(newrelicAppName),
 			newrelic.ConfigLicense(newrelicLicenseKey),
 		)
 		if err == nil {

--- a/main_test.go
+++ b/main_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Opsani
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestRoot(t *testing.T) {
+	app := newApp()
+	req := httptest.NewRequest("GET", "http://localhost:8080", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code: 200, got: %v", resp.StatusCode)
+	}
+
+	assertResponseBodyEquals(t, resp, "move along, nothing to see here")
+}
+
+func TestCPU(t *testing.T) {
+	app := newApp()
+	req := httptest.NewRequest("GET", "http://localhost:8080/cpu", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code: 200, got: %v", resp.StatusCode)
+	}
+	assertResponseBodyEquals(t, resp, "consumed CPU for 100ms\n")
+}
+
+func TestMemory(t *testing.T) {
+	app := newApp()
+	req := httptest.NewRequest("GET", "http://localhost:8080/memory", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code: 200, got: %v", resp.StatusCode)
+	}
+	assertResponseBodyEquals(t, resp, "allocated 10.00MB (10485760 bytes) of memory\n")
+}
+
+func TestTime(t *testing.T) {
+	app := newApp()
+	req := httptest.NewRequest("GET", "http://localhost:8080/time", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code: 200, got: %v", resp.StatusCode)
+	}
+	assertResponseBodyEquals(t, resp, "slept for 100ms\n")
+}
+
+func TestRequest(t *testing.T) {
+	app := newApp()
+	req := httptest.NewRequest("GET", "http://localhost:8080/request?url=http://opsani.com/", nil)
+
+	resp, err := app.Test(req)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	if resp.StatusCode != 200 {
+		t.Errorf("expected status code: 200, got: %v", resp.StatusCode)
+	}
+}
+
+func assertResponseBodyEquals(t *testing.T, resp *http.Response, expected string) {
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err.Error())
+	}
+	actual := string(body)
+	if actual != expected {
+		t.Errorf("expected %q but got %q", expected, actual)
+	}
+}


### PR DESCRIPTION
Added envar support to optionally configure the listening port.

Added call handler via os/exec to curl out to a specified remote URL.

Added environment variable handler for optional NEW_RELIC_APP_NAME.  However, NEW_RELIC_LICENSE_KEY remains the key environment variable for determining whether or not we're using New Relic.

Tested on local MacOS.
Tested via default (not specifying NEW_RELIC_APP_NAME) AND 
Tested via supplying NEW_RELIC_APP_NAME.