### PR TITLE
Add note about port numbers

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ By default, the server listens on HTTP port 8480 and HTTPS port 8843 (N + 8400).
 The port can be changed via the `HTTP_PORT` and `HTTPS_PORT` environment
 variables, respectively.
 
+### NOTE: Port numbers must be preceeded by a `:` e.g. `:8443`
+
 ## Initial memory allocation
 
 An initial resident memory allocation be created by setting the


### PR DESCRIPTION
The port numbers passed by environment variable need to be preceeded by a `:`.  This fix adds a note to the README to make end users aware of this requirement.